### PR TITLE
fixed homepage content size on mobile

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -15,6 +15,11 @@ body {
 
 }
 
+.screenshot-big img {
+    width: 100%;
+    max-width: 720px;
+}
+
 .bs-docs-sidebar .nav>li>a {
     padding: 4px 20px;
     color: gray;

--- a/html/index.html
+++ b/html/index.html
@@ -28,8 +28,8 @@
 </div>
 
 <div class="row">
-    <div class="span4 screenshot-big">
-        <img src="/img/runtimejs_3.png" width="720" />
+    <div class="col-lg-12 screenshot-big">
+        <img src="/img/runtimejs_3.png"/>
     </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@
 </div>
 
 <div class="row">
-    <div class="span4 screenshot-big">
-        <img src="/img/runtimejs_3.png" width="720" />
+    <div class="col-lg-12 screenshot-big">
+        <img src="/img/runtimejs_3.png"/>
     </div>
 </div>
 


### PR DESCRIPTION
It used to do this on mobile:
![screen shot 2014-09-15 at 10 23 33](https://cloud.githubusercontent.com/assets/298742/4269280/5b3cb1ca-3cba-11e4-8324-e56e1eb02fbd.png)
(note the massive area to the right)

It will now do this on mobile:
![screen shot 2014-09-15 at 10 24 20](https://cloud.githubusercontent.com/assets/298742/4269396/994faafc-3cbb-11e4-85cd-f7c780c1af11.png)
Responsive!
